### PR TITLE
fix: use while for pthread_cond_wait to guard against spurious wakeups

### DIFF
--- a/src/dw_subprob.c
+++ b/src/dw_subprob.c
@@ -379,7 +379,7 @@ int signal_availability(subprob_struct* my_data) {
 
 	/* Wait for signal here... */
 	pthread_mutex_lock(&next_iteration_mutex);
-	if (signals->current_iteration == my_data->local_iteration) {
+	while (signals->current_iteration == my_data->local_iteration) {
 		pthread_cond_wait(&next_iteration_cv, &next_iteration_mutex);
 	}
 	pthread_mutex_unlock(&next_iteration_mutex);

--- a/src/dw_subprob.c
+++ b/src/dw_subprob.c
@@ -379,7 +379,7 @@ int signal_availability(subprob_struct* my_data) {
 
 	/* Wait for signal here... */
 	pthread_mutex_lock(&next_iteration_mutex);
-	while (signals->current_iteration == my_data->local_iteration) {
+	while(signals->current_iteration == my_data->local_iteration) {
 		pthread_cond_wait(&next_iteration_cv, &next_iteration_mutex);
 	}
 	pthread_mutex_unlock(&next_iteration_mutex);


### PR DESCRIPTION
signal_availability() in dw_subprob.c used 'if' to guard pthread_cond_wait. POSIX permits spurious wakeups; 'if' lets a thread proceed with stale dual values. Change to 'while' so the predicate (current_iteration == local_iteration) is re-checked after every wakeup. Legitimate wakeups always satisfy the exit condition because every broadcast of next_iteration_cv increments signals->current_iteration under next_iteration_mutex first.