### PR TITLE
fix(006): handle CRLF line endings in guidefile parser

### DIFF
--- a/src/dw_support.c
+++ b/src/dw_support.c
@@ -557,7 +557,11 @@ int process_cmdline(int argc, char* argv[], faux_globals* fg) {
  		fg->subproblem_names[i] = malloc(sizeof(char)*BUFF_SIZE);
  		dw_oom_abort(fg->subproblem_names[i], "fg->subproblem_names[i]");
  		fgets(fg->subproblem_names[i], BUFF_SIZE, input_file);
- 		fg->subproblem_names[i][strlen(fg->subproblem_names[i])-1] = '\0';
+		{
+			size_t len = strlen(fg->subproblem_names[i]);
+			while (len > 0 && (fg->subproblem_names[i][len-1] == '\n' || fg->subproblem_names[i][len-1] == '\r'))
+				fg->subproblem_names[i][--len] = '\0';
+		}
  		if( (subproblem_files[i] = fopen(fg->subproblem_names[i], "r")) == NULL ) {
  			dw_printf(IMPORTANCE_VITAL, "Problem opening file: %s\n", fg->subproblem_names[i]);
  			return 1;
@@ -574,7 +578,11 @@ int process_cmdline(int argc, char* argv[], faux_globals* fg) {
 
  	/* Get master file name. */
  	fgets(fg->master_name, BUFF_SIZE, input_file);
- 	fg->master_name[strlen(fg->master_name)-1] = '\0';
+	{
+		size_t len = strlen(fg->master_name);
+		while (len > 0 && (fg->master_name[len-1] == '\n' || fg->master_name[len-1] == '\r'))
+			fg->master_name[--len] = '\0';
+	}
  	if( (master_file = fopen(fg->master_name, "r")) == NULL ) {
  		dw_printf(IMPORTANCE_VITAL, "Problem opening master file: %s\n", fg->master_name);
  		return 1;
@@ -592,7 +600,11 @@ int process_cmdline(int argc, char* argv[], faux_globals* fg) {
  	 */
  	if( fg->get_monolithic_file ) {
  		fgets(fg->monolithic_name, BUFF_SIZE, input_file);
- 		fg->monolithic_name[strlen(fg->monolithic_name)-1] = '\0';
+		{
+			size_t len = strlen(fg->monolithic_name);
+			while (len > 0 && (fg->monolithic_name[len-1] == '\n' || fg->monolithic_name[len-1] == '\r'))
+				fg->monolithic_name[--len] = '\0';
+		}
  		/*
  		if( (monolithic_file = fopen(fg->monolithic_name, "r")) == NULL ) {
  			printf("Problem opening master file: %s\n", fg->monolithic_name);

--- a/src/dw_support.c
+++ b/src/dw_support.c
@@ -409,6 +409,13 @@ void print_usage(int argc, char* argv[]) {
 	printf("\n");
 }
 
+/* Strip trailing \r and \n from a line read by fgets(). */
+static void chomp_crlf(char *s) {
+	size_t len = strlen(s);
+	while (len > 0 && (s[len-1] == '\n' || s[len-1] == '\r'))
+		s[--len] = '\0';
+}
+
 /* Simple processing of command line. Probably many more options would be
  * useful. */
 int process_cmdline(int argc, char* argv[], faux_globals* fg) {
@@ -556,12 +563,11 @@ int process_cmdline(int argc, char* argv[], faux_globals* fg) {
  	for( i = 0; i < fg->num_clients; i++ ) {
  		fg->subproblem_names[i] = malloc(sizeof(char)*BUFF_SIZE);
  		dw_oom_abort(fg->subproblem_names[i], "fg->subproblem_names[i]");
- 		fgets(fg->subproblem_names[i], BUFF_SIZE, input_file);
-		{
-			size_t len = strlen(fg->subproblem_names[i]);
-			while (len > 0 && (fg->subproblem_names[i][len-1] == '\n' || fg->subproblem_names[i][len-1] == '\r'))
-				fg->subproblem_names[i][--len] = '\0';
+ 		if (fgets(fg->subproblem_names[i], BUFF_SIZE, input_file) == NULL) {
+			dw_printf(IMPORTANCE_VITAL, "Exiting: guidefile truncated reading subproblem %d\n", i);
+			return 1;
 		}
+		chomp_crlf(fg->subproblem_names[i]);
  		if( (subproblem_files[i] = fopen(fg->subproblem_names[i], "r")) == NULL ) {
  			dw_printf(IMPORTANCE_VITAL, "Problem opening file: %s\n", fg->subproblem_names[i]);
  			return 1;
@@ -577,12 +583,11 @@ int process_cmdline(int argc, char* argv[], faux_globals* fg) {
  	}
 
  	/* Get master file name. */
- 	fgets(fg->master_name, BUFF_SIZE, input_file);
-	{
-		size_t len = strlen(fg->master_name);
-		while (len > 0 && (fg->master_name[len-1] == '\n' || fg->master_name[len-1] == '\r'))
-			fg->master_name[--len] = '\0';
+	if (fgets(fg->master_name, BUFF_SIZE, input_file) == NULL) {
+		dw_printf(IMPORTANCE_VITAL, "Exiting: guidefile truncated reading master name\n");
+		return 1;
 	}
+	chomp_crlf(fg->master_name);
  	if( (master_file = fopen(fg->master_name, "r")) == NULL ) {
  		dw_printf(IMPORTANCE_VITAL, "Problem opening master file: %s\n", fg->master_name);
  		return 1;
@@ -599,12 +604,11 @@ int process_cmdline(int argc, char* argv[], faux_globals* fg) {
  	 * altogether and fix my old guidefiles...
  	 */
  	if( fg->get_monolithic_file ) {
- 		fgets(fg->monolithic_name, BUFF_SIZE, input_file);
-		{
-			size_t len = strlen(fg->monolithic_name);
-			while (len > 0 && (fg->monolithic_name[len-1] == '\n' || fg->monolithic_name[len-1] == '\r'))
-				fg->monolithic_name[--len] = '\0';
+ 		if (fgets(fg->monolithic_name, BUFF_SIZE, input_file) == NULL) {
+			dw_printf(IMPORTANCE_VITAL, "Exiting: guidefile truncated reading monolithic name\n");
+			return 1;
 		}
+		chomp_crlf(fg->monolithic_name);
  		/*
  		if( (monolithic_file = fopen(fg->monolithic_name, "r")) == NULL ) {
  			printf("Problem opening master file: %s\n", fg->monolithic_name);

--- a/tests/fixtures/crlf_single_sub.guidefile
+++ b/tests/fixtures/crlf_single_sub.guidefile
@@ -1,0 +1,4 @@
+1
+../examples/single_sub/sub1.cplex
+../examples/single_sub/master.cplex
+../examples/single_sub/dw_monolithic.cplex

--- a/tests/test_guidefile.sh
+++ b/tests/test_guidefile.sh
@@ -101,6 +101,17 @@ _rc=$?
 assert_exit "missing_file no crash" no_crash "$_rc"
 assert_exit "missing_file non-zero exit" nonzero "$_rc"
 
+# CRLF edge case: guidefile with Windows-style \r\n line endings
+echo "Test: CRLF guidefile (Windows-style line endings)"
+_out=$(dwsolver --no-write-final-master --quiet -g fixtures/crlf_single_sub.guidefile 2>&1)
+_rc=$?
+assert_exit "crlf guidefile no crash" no_crash "$_rc"
+assert_exit "crlf guidefile succeeds" zero "$_rc"
+if echo "$_out" | grep -q "USAGE:\|Problem opening"; then
+    echo "  FAIL: crlf guidefile failed to open files (\\r not stripped)"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
 echo ""
 echo "=== Results: $PASS_COUNT passed, $FAIL_COUNT failed ==="
 if [ "$FAIL_COUNT" -ne 0 ]; then


### PR DESCRIPTION
The guidefile parser stripped only the trailing \n with strlen-1, leaving \r embedded in filenames from Windows-style \r\n line endings. This caused fopen to fail on POSIX systems when a guidefile was created on Windows.

Fix: replace the single-character strip with a while loop that removes both \r and \n from the end of each filename read from the guidefile (subproblem names, master name, monolithic name).

Test: add tests/fixtures/crlf_single_sub.guidefile (actual CRLF endings) and a corresponding test case in tests/test_guidefile.sh that asserts a CRLF guidefile succeeds (exit 0) rather than failing with 'Problem opening file'.